### PR TITLE
Suppress unnecessary Xclose messages

### DIFF
--- a/pymonetdb/sql/cursors.py
+++ b/pymonetdb/sql/cursors.py
@@ -177,7 +177,7 @@ class Cursor(object):
         self._store_result(block)
         self.rownumber = 0
         self._executed = operation
-        self._must_close_resultset = self.rowcount > len(self._rows)
+        self._must_close_resultset = self._rows and self.rowcount > len(self._rows)
         return self.rowcount
 
     def executemany(self, operation, seq_of_parameters):


### PR DESCRIPTION
If a result set is larger than N rows, where N means 100 rows or whatever was set using `Connection.set_replysize`, only the first N rows are set to the client initially. The other rows remain on the server until the client asks for them. The client must send an explicit `Xclose` message to discard the server side row buffer when no more rows are needed.
In pymonetdb this happens when the cursor is closed or right before it executes another SQL statement.
The logic to do so was flawed:
```python
    self._must_close_resultset = self.rowcount > len(self._rows)
```
Unfortunately, the rowcount is also used to hold the number of affected rows of for example INSERT statements. In such as case, `self.rowcount` would be greater than 0 and `self._rows` would be empty, leading to an unnecessary `Xclose` message.