### PR TITLE
Support local control connections again

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,7 @@ jobs:
           sudo -u monetdb monetdbd set control=yes ${{ env.DBFARM }}
           sudo -u monetdb monetdbd set passphrase=testdb ${{ env.DBFARM }}
           sudo -u monetdb monetdbd start ${{ env.DBFARM }}
+          sudo -u monetdb chmod o+rwx /tmp/.s.mero*
       - name: Create MonetDB test database
         run: |
           sudo -u monetdb monetdb create demo

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -463,6 +463,7 @@ class Connection(object):
         """
         parts = []
         while True:
+            assert self.socket
             received = self.socket.recv(4096)
             if not received:
                 break
@@ -513,7 +514,6 @@ class Connection(object):
         block = memoryview(block)
         while pos < end:
             data = block[pos:pos + 8192]
-            length = len(data)
             nsent = self.socket.send(data)
             pos += nsent
         self.socket.shutdown(socket.SHUT_WR)

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -488,7 +488,7 @@ class Connection(object):
         data = block.encode('utf-8')
         if self.language == 'control' and not self.hostname:
             # control does not use the blocking protocol
-            return self._send_all(data)
+            return self._send_all_and_shutdown(data)
         else:
             self._putblock_raw(block.encode(), True)
 
@@ -506,7 +506,7 @@ class Connection(object):
             self.socket.send(data)
             pos += length
 
-    def _send_all(self, block):
+    def _send_all_and_shutdown(self, block):
         """ put the data into the socket """
         pos = 0
         end = len(block)
@@ -516,6 +516,7 @@ class Connection(object):
             length = len(data)
             nsent = self.socket.send(data)
             pos += nsent
+        self.socket.shutdown(socket.SHUT_WR)
 
     def __del__(self):
         if self.socket:

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -382,6 +382,10 @@ class Connection(object):
 
     def _getblock_and_transfer_files(self):
         """ read one mapi encoded block and take care of any file transfers the server requests"""
+        if self.language == 'control' and not self.hostname:
+            # control connections do not use the blocking protocol and do not transfer files
+            return self._recv_to_end()
+
         buffer = self._get_buffer()
         offset = 0
 
@@ -405,6 +409,9 @@ class Connection(object):
 
     def _getblock(self) -> str:
         """ read one mapi encoded block """
+        if self.language == 'control' and not self.hostname:
+            # control connections do not use the blocking protocol
+            return self._recv_to_end()
         buf = self._get_buffer()
         end = self._getblock_raw(buf, 0)
         ret = str(memoryview(buf)[:end], 'utf-8')
@@ -450,6 +457,18 @@ class Connection(object):
             offset += n
         return end
 
+    def _recv_to_end(self) -> str:
+        """
+        Read bytes from the socket until the server closes the connection
+        """
+        parts = []
+        while True:
+            received = self.socket.recv(4096)
+            if not received:
+                break
+            parts.append(received)
+        return str(b"".join(parts).strip(), 'utf-8')
+
     def _get_buffer(self) -> bytearray:
         """Retrieve a previously stashed buffer for reuse, or create a new one"""
         if self.stashed_buffer:
@@ -466,13 +485,15 @@ class Connection(object):
 
     def _putblock(self, block):
         """ wrap the line in mapi format and put it into the socket """
-        self._putblock_inet_raw(block.encode(), True)
+        data = block.encode('utf-8')
+        if self.language == 'control' and not self.hostname:
+            # control does not use the blocking protocol
+            return self._send_all(data)
+        else:
+            self._putblock_raw(block.encode(), True)
 
-    def _putblock_raw(self, block, finish: bool):
+    def _putblock_raw(self, block, finish):
         """ put the data into the socket """
-        self._putblock_inet_raw(block, finish)
-
-    def _putblock_inet_raw(self, block, finish):
         pos = 0
         last = 0
         while not last:
@@ -484,6 +505,17 @@ class Connection(object):
             self.socket.send(flag)
             self.socket.send(data)
             pos += length
+
+    def _send_all(self, block):
+        """ put the data into the socket """
+        pos = 0
+        end = len(block)
+        block = memoryview(block)
+        while pos < end:
+            data = block[pos:pos + 8192]
+            length = len(data)
+            nsent = self.socket.send(data)
+            pos += nsent
 
     def __del__(self):
         if self.socket:

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -32,7 +32,7 @@ class TestControl(unittest.TestCase):
 
     def setUpControl(self):
         # use tcp
-        return Control(test_hostname, test_port, test_passphrase)
+        return Control(hostname=test_hostname, port=test_port, passphrase=test_passphrase)
 
     def setUp(self):
         self.control = self.setUpControl()
@@ -143,5 +143,5 @@ class TestControl(unittest.TestCase):
 
 class TestLocalControl(TestControl):
     def setUpControl(self):
-        # use socket
-        return Control()
+        # use unix domain socket
+        return Control(port=test_port, passphrase=test_passphrase)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -30,12 +30,12 @@ class TestControl(unittest.TestCase):
     Where /var/lib/monetdb is the path to your dbfarm. Don't forget to restart the db after setting the credentials.
     """
 
-    def setUp(self):
+    def setUpControl(self):
         # use tcp
-        self.control = Control(test_hostname, test_port, test_passphrase)
+        return Control(test_hostname, test_port, test_passphrase)
 
-        # use socket
-        # self.control = Control()
+    def setUp(self):
+        self.control = self.setUpControl()
 
         do_without_fail(lambda: self.control.stop(database_name))
         do_without_fail(lambda: self.control.destroy(database_name))
@@ -139,3 +139,9 @@ class TestControl(unittest.TestCase):
     @unittest.skipUnless(test_full, "full test disabled")
     def test_neighbours(self):
         self.control.neighbours()
+
+@unittest.skipUnless(test_full, "full test disabled")
+class TestLocalControl(TestControl):
+    def setUpControl(self):
+        # use socket
+        return Control()

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -140,6 +140,7 @@ class TestControl(unittest.TestCase):
     def test_neighbours(self):
         self.control.neighbours()
 
+
 class TestLocalControl(TestControl):
     def setUpControl(self):
         # use socket

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -140,7 +140,6 @@ class TestControl(unittest.TestCase):
     def test_neighbours(self):
         self.control.neighbours()
 
-@unittest.skipUnless(test_full, "full test disabled")
 class TestLocalControl(TestControl):
     def setUpControl(self):
         # use socket


### PR DESCRIPTION
My ON CLIENT changes broke control connections to monetdb's unix domain socket (/tmp/.s.merovingian.50000). This PR fixes that. It also makes it much faster.

Fixes #111 