### PR TITLE
Bug: filenames with whitespaces

### DIFF
--- a/pymonetdb/filetransfer/__init__.py
+++ b/pymonetdb/filetransfer/__init__.py
@@ -40,7 +40,7 @@ def handle_file_transfer(mapi: "Connection", cmd: str):
     else:
         pass
     # we only reach this if decoding the cmd went wrong:
-    mapi._putblock(f"Invalid file transfer command: {cmd!r}")
+    mapi._putblock(f"Invalid file transfer command: {cmd!r}\n")
 
 
 def handle_upload(mapi: "Connection", filename: str, text_mode: bool, offset: int):

--- a/pymonetdb/filetransfer/__init__.py
+++ b/pymonetdb/filetransfer/__init__.py
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
 
 def handle_file_transfer(mapi: "Connection", cmd: str):
     if cmd.startswith("r "):
-        parts = cmd[2:].split(' ', 2)
+        parts = cmd[2:].split(' ', 1)
         if len(parts) == 2:
             try:
                 n = int(parts[0])

--- a/pymonetdb/filetransfer/__init__.py
+++ b/pymonetdb/filetransfer/__init__.py
@@ -19,6 +19,8 @@ if typing.TYPE_CHECKING:
 
 def handle_file_transfer(mapi: "Connection", cmd: str):
     if cmd.startswith("r "):
+        # r 0 filename.txt
+        # where 0 is the number of lines to skip
         parts = cmd[2:].split(' ', 1)
         if len(parts) == 2:
             try:
@@ -27,10 +29,13 @@ def handle_file_transfer(mapi: "Connection", cmd: str):
                 pass
             return handle_upload(mapi, parts[1], True, n)
     elif cmd.startswith("rb "):
+        # rb filename.bin
         return handle_upload(mapi, cmd[3:], False, 0)
     elif cmd.startswith("w "):
+        # w filename.txt
         return handle_download(mapi, cmd[2:], True)
     elif cmd.startswith("wb "):
+        # wb filename.bin
         return handle_download(mapi, cmd[3:], False)
     else:
         pass

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -88,10 +88,12 @@ class Connection(object):
     MAPI (low level MonetDB API) connection
     """
 
+    socket: Optional[socket.socket]
+
     def __init__(self):
         self.state = STATE_INIT
         self._result = None
-        self.socket: Optional[socket.socket] = None
+        self.socket = None
         self.unix_socket = None
         self.hostname = ""
         self.port = 0

--- a/tests/test_filetransfer.py
+++ b/tests/test_filetransfer.py
@@ -365,6 +365,9 @@ class TestFileTransfer(TestCase, Common):
 
     def test_upload_unix_binary_file(self):
         self.upload_file('unix.csv', dict(newline="\n"), False)
+    
+    def test_upload_native_text_filename_w_whitespaces(self):
+        self.upload_file('filename with spaces.csv', {}, True)
 
     def upload_file(self, filename, write_opts, read_text):
         encoding = self.defaultencoding if read_text else 'utf-8'

--- a/tests/test_filetransfer.py
+++ b/tests/test_filetransfer.py
@@ -365,7 +365,7 @@ class TestFileTransfer(TestCase, Common):
 
     def test_upload_unix_binary_file(self):
         self.upload_file('unix.csv', dict(newline="\n"), False)
-    
+
     def test_upload_native_text_filename_w_whitespaces(self):
         self.upload_file('filename with spaces.csv', {}, True)
 

--- a/tests/test_filetransfer.py
+++ b/tests/test_filetransfer.py
@@ -123,6 +123,7 @@ class DeadManHandle:
     deadlocks, but can be inconvenient when running tests in the debugger. In
     that case, temporarily call deadman.cancel() at the start of the test.
     """
+
     def __init__(self):
         self.cond = Condition()
         self.deadline = None
@@ -538,7 +539,11 @@ class TestSafeDirectoryHandler(TestCase, Common):
                         self.execute("COPY (SELECT * FROM foo) INTO %s ON CLIENT", [path])
                     continue
 
-    def get_testdata_name(self, enc_name: str, newline: str, lines: int = None, compression=None) -> str:
+    def get_testdata_name(self,
+                          enc_name: str, newline: str,
+                          lines: Optional[int] = None,
+                          compression: Optional[str] = None
+                          ) -> str:
         newline_name = {None: "none", "\n": "lf", "\r\n": "crlf"}[newline]
         file_name = f"{enc_name}_{newline_name}"
         if lines is not None:
@@ -548,7 +553,7 @@ class TestSafeDirectoryHandler(TestCase, Common):
             file_name += "." + compression
         return file_name
 
-    def get_testdata(self, enc_name: str, newline: str, lines: int, compression: str = None) -> str:
+    def get_testdata(self, enc_name: str, newline: str, lines: int, compression: Optional[str] = None) -> str:
         encoding = codecs.lookup(enc_name) if enc_name else None
         fname = self.get_testdata_name(enc_name, newline, lines, compression)
         p = self.file(fname)


### PR DESCRIPTION
when trying to COPY INTO ON CLIENT for a file with a whitespace in its filename (eg `my file.csv` i realized that the client was hanging. since i was not sure whose fault that was i investigated both the server and the client and realized that they were in a state that seems as a deadlock.

for the server i had my connection's thread stuck at 
```c
// common/stream/socket_stream.c:127
ret = poll(&pfd, 1, (int) s->timeout);
```

and the client at
```py
# mapi.py:447
n = self.socket.recv_into(view)
```

only after killing the client the server was logging
```txt
ON CLIENT: Invalid file transfer command: 'r 0 my file.csv'
```

apparently it was the client generating and sending the message to the server due to the erroneous split. 

now since looking at the code i'm not sure if that double `split()` of the `cmd` on the whitespace could serve any other need but i changed it in any case since it was creating this situation.

as for this "deadlock" i haven't review the exact conditions that lead there. i strongly feel that there is **another bug**: the client probably should have closed the connection after sending the `Invalid file transfer command` msg.

@joerivanruth let me know what you think!
