### PR TITLE
Allow to use Connection and Cursor as context managers

### DIFF
--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -108,7 +108,7 @@ class Connection:
         """
         try:
             self.close()
-        except exceptions.Error as e:
+        except exceptions.Error:
             pass
         # Propagate any errors
         return False

--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -98,6 +98,21 @@ class Connection:
         else:
             raise exceptions.Error("already closed")
 
+    def __enter__(self):
+        """This method is invoked when this Connection is used in a with-statement.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """This method is invoked when this Connection is used in a with-statement.
+        """
+        try:
+            self.close()
+        except exceptions.Error as e:
+            pass
+        # Propagate any errors
+        return False
+
     def set_autocommit(self, autocommit):
         """
         Set auto commit on or off. 'autocommit' must be a boolean

--- a/pymonetdb/sql/cursors.py
+++ b/pymonetdb/sql/cursors.py
@@ -143,7 +143,7 @@ class Cursor(object):
         """
         try:
             self.close()
-        except Error as e:
+        except Error:
             pass
         # Propagate any errors
         return False

--- a/pymonetdb/sql/cursors.py
+++ b/pymonetdb/sql/cursors.py
@@ -133,6 +133,21 @@ class Cursor(object):
             pass
         self.connection = None
 
+    def __enter__(self):
+        """This method is invoked when this Cursor is used in a with-statement.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """This method is invoked when this Cursor is used in a with-statement.
+        """
+        try:
+            self.close()
+        except Error as e:
+            pass
+        # Propagate any errors
+        return False
+
     def execute(self, operation: str, parameters: Optional[Dict] = None):
         """Prepare and execute a database operation (query or
         command).  Parameters may be provided as mapping and

--- a/tests/test_contextmanager.py
+++ b/tests/test_contextmanager.py
@@ -1,0 +1,90 @@
+"""
+This is the python implementation of the mapi protocol.
+"""
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0.  If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 1997 - July 2008 CWI, August 2008 - 2016 MonetDB B.V.
+
+
+from unittest import TestCase
+
+import pymonetdb
+from tests.util import test_args
+
+
+class TestContextManager(TestCase):
+
+    def connect(self):
+        return pymonetdb.connect(**test_args)
+
+    def test_context_manager(self):
+        """Test using a Connection in a with-clause"""
+        with self.connect() as conn, conn.cursor() as c:
+            c.execute("SELECT 42")
+            self.assertEqual(c.fetchone()[0], 42)
+
+    def test_connection_closes_when_ok(self):
+        x = self.connect()
+        self.assertIsNotNone(x.mapi)
+        try:
+            with x as conn:
+                y = conn.cursor()
+                self.assertIsNotNone(y.connection)
+                try:
+                    with y as c:
+                        c.execute("SELECT 42")
+                        self.assertEqual(c.fetchone()[0], 42)
+                finally:
+                    # check cursor is closed
+                    self.assertIsNone(y.connection)
+        finally:
+            # check connection is closed
+            self.assertIsNone(x.mapi)
+
+    def test_connection_closes_when_sql_error(self):
+        try:
+            x = self.connect()
+            self.assertIsNotNone(x.mapi)
+            try:
+                with x as conn:
+                    y = conn.cursor()
+                    self.assertIsNotNone(y.connection)
+                    try:
+                        with y as c:
+                            c.execute("SELECT 42x")   # This fails
+                            self.assertEqual(c.fetchone()[0], 42)
+                    finally:
+                        # check cursor is closed
+                        self.assertIsNone(y.connection)
+            finally:
+                # check connection is closed
+                self.assertIsNone(x.mapi)
+        except pymonetdb.exceptions.OperationalError as e:
+            if "Unexpected symbol x" in str(e):
+                pass
+            else:
+                raise e
+
+    def test_connection_closes_when_other_error(self):
+        try:
+            x = self.connect()
+            self.assertIsNotNone(x.mapi)
+            try:
+                with x as conn:
+                    y = conn.cursor()
+                    self.assertIsNotNone(y.connection)
+                    try:
+                        with y as c:
+                            one = len([c])
+                            zero = 0
+                            one / zero
+                    finally:
+                        # check cursor is closed
+                        self.assertIsNone(y.connection)
+            finally:
+                # check connection is closed
+                self.assertIsNone(x.mapi)
+        except ZeroDivisionError:
+            pass

--- a/tests/test_contextmanager.py
+++ b/tests/test_contextmanager.py
@@ -49,7 +49,6 @@ class TestContextManager(TestCase):
             # check connection is closed
             self.assertIsNone(x.mapi)
 
-
     def test_connection_closes_when_sql_error(self):
         x = self.connect()
         y = x.cursor()
@@ -57,6 +56,9 @@ class TestContextManager(TestCase):
         self.assertIsNotNone(y.connection)
         with self.assertRaisesRegex(OperationalError, expected_regex="Unexpected symbol"):
             with x as conn:
+                # suppress warning about unused 'conn'
+                if conn:
+                    pass
                 with y as cursor:
                     cursor.execute("SELECT 42zzz")   # This fails
                     self.fail("the statement above should have raised an exception")
@@ -71,9 +73,15 @@ class TestContextManager(TestCase):
         self.assertIsNotNone(y.connection)
         with self.assertRaises(ZeroDivisionError):
             with x as conn:
+                # suppress warning about unused 'conn'
+                if conn:
+                    pass
                 with y as cursor:
+                    # suppress warning about unused 'conn' and 'cursor'
+                    if conn or cursor:
+                        pass
                     # create a ZeroDivisionError without static analyzers noticing it
-                    one = len([cursor])
+                    one = 1
                     zero = 0
                     one / zero
                     self.fail("the statement above should have raised an exception")


### PR DESCRIPTION
That is, the statement

    with pymonetdb.connect('db') as conn, conn.cursor() as cursor:
        cursor.execute("SELECT 42")

automatically closes the cursor and the connection regardless of whether .execute succeeds.

This is not required by DBAPI 2.0 but many other implementations do this as well.