### PR TITLE
Send a number of NUL bytes on new TCP connections     

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -212,6 +212,7 @@ class Connection(object):
         """ Reads challenge from line, generate response and check if
         everything is okay """
 
+        assert self.socket
         self.socket.sendall(b'\x00\x00\x00\x00\x00\x00\x00\x00')
 
         challenge = self._getblock()

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -212,6 +212,8 @@ class Connection(object):
         """ Reads challenge from line, generate response and check if
         everything is okay """
 
+        self.socket.sendall(b'\x00\x00\x00\x00\x00\x00\x00\x00')
+
         challenge = self._getblock()
         response = self._challenge_response(challenge, password)
         self._putblock(response)


### PR DESCRIPTION
This forces an error message when accidentally connecting to a TLS server.
Also, surprisingly it seems to make connection setup slightly faster!
